### PR TITLE
Removed NodePort Exports

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -50,11 +50,6 @@ Vagrant.configure("2") do |config|
         bridge: "wlp8s0"
       master.vm.hostname="master"
       master.vm.synced_folder "/mnt/vmount/data/master", "/vagrant_data"
-# Provider-specific configuration so you can fine-tune various
-# backing providers for Vagrant. These expose provider-specific options.
-      for i in 30000..32767
-          master.vm.network :forwarded_port, guest: i, host: i
-      end
       master.vm.network "forwarded_port", guest: 6443, host: 6443
 
       master.vm.provider "virtualbox" do |mvb|
@@ -73,13 +68,6 @@ Vagrant.configure("2") do |config|
        worker.vm.hostname="worker"
        worker.vm.synced_folder "/mnt/vmount/data/worker", "/vagrant_data"
        worker.vm.network "forwarded_port", guest: 10250, host: 10250
-       ## exporting all node port, while its not mandatory
-       ## components like service mesh & ingress conmtroller use external
-       ## load balancers, as we wont have this option nodeport is a alternate
-       for i in 30000..32767
-           worker.vm.network :forwarded_port, guest: i, host: i
-       end
-
        worker.vm.provider "virtualbox" do |wvb|
           wvb.memory = "4096"
           wvb.cpus = "3"


### PR DESCRIPTION
removed port forwarding of Node Ports, as there's a better way to do this using software loadbalancers